### PR TITLE
Awair OUI check

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Homebridge Awair2",
   "name": "homebridge-awair2",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "HomeKit integration of Awair air purifier as Dynamic Platform.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,14 +133,23 @@ class AwairPlatform implements DynamicPlatformPlugin {
 
 	  // Get Awair devices from your account defined by Developer Access Token
 	  await this.getAwairDevices();
-		
+
 	  const serNums: string[] = []; // array to keep track of devices
 
 	  // Add accessory for each Awair device
 	  for (let i = 0; i < this.devices.length; i++) {
 	    const device = this.devices[i];
-	    if (!this.ignoredDevices.includes(device.macAddress)) {
+	    if (!this.ignoredDevices.includes(device.macAddress) && device.macAddress.includes('70886B')) {
+	      
+	      // must NOT be on ignored list AND must contain the Awair OUI "70886B", the NIC can be any hexadecimal string
 	      await this.addAccessory.bind(this, device)();
+	    } else {
+	      if (this.config.logging) {
+	        
+	        // both conditions above _should_ be satisfied, unless the MAC is missing (contact Awair), incorrect, or a testing device
+	        this.log('[' + accessory.context.serial + '] Error with Serial...' + device.macAddress + ' On ignore list or does not match Awair OUI "70886B"');
+	      }
+	      
 	    }
 	    serNums.push(device.macAddress);
 	  }


### PR DESCRIPTION
MAC must match Awair OUI that contains "70886B", unless the MAC is missing (contact Awair), incorrect, or a testing device

The main need for this logic check is that the ignore list is built entirely on the need for a valid MAC, therefore in order to remove a device without a valid MAC, it should not be included in the first place.

However, some other approaches I could see to this...
1. use device_uuid on the ignore list instead of MAC (or "either/or")
2. allow a check for a special case: add an ignored device via "unknown" or "not valid MAC" in order to exclude these devices rather than block them

Let me know what you think, @DMBlakeley.