### PR TITLE
Append .local domain suffix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1122,8 +1122,8 @@ class AwairPlatform implements DynamicPlatformPlugin {
   
   async updateLocalAirQualityData(accessory: PlatformAccessory): Promise<void> {
     // Update air quality data for accessory of deviceId
-    const url = `http://${accessory.context.deviceType.substr(0, 10)}-${accessory.context.serial.substr(6)}/air-data/latest`;
-			
+    const url = `http://${accessory.context.deviceType.substr(0, 10)}-${accessory.context.serial.substr(6)}.local/air-data/latest`;
+
     await axios.get(url)
       .then(response => {
         const data: any = response.data;
@@ -1340,7 +1340,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	 * @param {object} accessory - accessory to obtain battery status
 	 */
   async getBatteryStatus(accessory: PlatformAccessory): Promise<void> {
-	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.substr(6)}/settings/config/data`;
+	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.substr(6)}.local/settings/config/data`;
 
 	  await axios.get(url)
     	.then(response => {
@@ -1380,7 +1380,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	 * @param {object} accessory - accessory to obtain occupancy status
 	 */
   async getOccupancyStatus(accessory: PlatformAccessory): Promise<void> {
-	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.substr(6)}/air-data/latest`;
+	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.substr(6)}.local/air-data/latest`;
 
     await axios.get(url)
     	.then(response => {


### PR DESCRIPTION
Closes https://github.com/DMBlakeley/homebridge-awair2/issues/903

The issue is that the plugin tries to resolve from a zeroconf name, but doesn't have the .local suffix. This works on some hosts/networks but not all. Adding the .local suffix disambiguates that it's a zeroconf hostname, and will generally work more reliably across more hosts (I think!).

Tested it with a local patch in node_modules and it seems to be working well. 