### PR TITLE
TypeScript 6.0 compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/).
 
+## v5.13.5
+* Update supported node.js versions to: [22.x, 24.x, 26.x]
+* Update `tsconfig.json` to conform to Typescript 6.0.
+
 ## v5.13.4
 * Updates to address minimatch security vulnerabilities.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## v5.13.5
 * Update supported node.js versions to: [22.x, 24.x, 26.x]
-* Update `tsconfig.json` to conform to Typescript 6.0.
+* Updates to conform to Typescript 6.0.
 
 ## v5.13.4
 * Updates to address minimatch security vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-awair2",
-  "version": "5.13.4",
+  "version": "5.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-awair2",
-      "version": "5.13.4",
+      "version": "5.13.5",
       "license": "ISC",
       "dependencies": {
         "@eslint/eslintrc": "^3.1.0",
@@ -30,11 +30,11 @@
         "nodemon": "^3.0.1",
         "rimraf": "^6.0.1",
         "ts-node": "^10.0.0",
-        "typescript": "^5.0.2"
+        "typescript": "^6.0.0"
       },
       "engines": {
-        "homebridge": "^1.8.0 || ^2.0.0-beta.0",
-        "node": "^20.18.0 || ^22.10.0 || ^24.11.0"
+        "homebridge": "^1.8.0 || ^2.0.0",
+        "node": "^22.10.0 || ^24.11.0 || ^26.1.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -102,9 +102,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -181,9 +181,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -239,9 +239,9 @@
       }
     },
     "node_modules/@homebridge/ciao": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.8.tgz",
-      "integrity": "sha512-lNhpCsZVbdbjz2trFjQdzQ3cUIMZQMIMksi7wd3ntTIYgdaGLqT1Ms97DfVIJYHzRuduf56ISvgU8RRLTpK/ng==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.9.tgz",
+      "integrity": "sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -255,9 +255,9 @@
       }
     },
     "node_modules/@homebridge/dbus-native": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.5.tgz",
-      "integrity": "sha512-SX4Mwg7JYED+o5WMz1+Y4FzGPGtXruDcwQt1SCkzfSqMTzrFj3uO5spEMn04Jj2kCqJVcrRQFWbqw+XW8suIXA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.6.tgz",
+      "integrity": "sha512-jvwmRYqe01+sP7XqOu7GdP2lHJhctI9MjRddPvgPb1KvsVKW/RrKjF/8CwTqv1vXkwcJHySpny7PYaiBGwtjRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -426,17 +426,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
+      "integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/type-utils": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/type-utils": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -449,7 +449,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.3",
+        "@typescript-eslint/parser": "^8.60.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -465,16 +465,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+      "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -490,14 +490,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.3",
-        "@typescript-eslint/types": "^8.59.3",
+        "@typescript-eslint/tsconfig-utils": "^8.60.0",
+        "@typescript-eslint/types": "^8.60.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -512,14 +512,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
+      "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3"
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -530,9 +530,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -547,15 +547,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
+      "integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0",
+        "@typescript-eslint/utils": "8.60.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -572,9 +572,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -586,16 +586,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.3",
-        "@typescript-eslint/tsconfig-utils": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/project-service": "8.60.0",
+        "@typescript-eslint/tsconfig-utils": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/visitor-keys": "8.60.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -614,16 +614,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
+      "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3"
+        "@typescript-eslint/scope-manager": "8.60.0",
+        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/typescript-estree": "8.60.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -638,13 +638,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "version": "8.60.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/types": "8.60.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -815,9 +815,9 @@
       }
     },
     "node_modules/bonjour-hap": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.2.tgz",
-      "integrity": "sha512-37ZEbMSKZ/K4O8sK9YDVFKJ62ZqlK4OPXcBUYaBnVlqr6vQjYwIoFuOQL0ZhztkCNgyyiCExfN4FcZB5cS9t1A==",
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/bonjour-hap/-/bonjour-hap-3.10.3.tgz",
+      "integrity": "sha512-KEaj40wsnI7diI44Bonr/XWzSzNoodVG4Uo40sQIsqvyEPxSjix3dyjdryDudrIlBFYJBAvfW57mZ6PRgsMImg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1102,9 +1102,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1239,9 +1239,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1710,9 +1710,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -1977,9 +1977,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
-      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2457,9 +2457,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2745,9 +2745,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": false,
   "displayName": "Homebridge Awair2",
   "name": "homebridge-awair2",
-  "version": "5.13.4",
+  "version": "5.13.5",
   "description": "HomeKit integration of Awair air quality monitor as Dynamic Platform.",
   "main": "dist/index.js",
   "scripts": {
@@ -27,8 +27,8 @@
   ],
   "author": "Douglas M. Blakeley",
   "engines": {
-    "node": "^20.18.0 || ^22.10.0 || ^24.11.0",
-    "homebridge": "^1.8.0 || ^2.0.0-beta.0"
+    "node": "^22.10.0 || ^24.11.0 || ^26.1.0",
+    "homebridge": "^1.8.0 || ^2.0.0"
   },
   "license": "ISC",
   "files": [
@@ -58,7 +58,7 @@
     "nodemon": "^3.0.1",
     "rimraf": "^6.0.1",
     "ts-node": "^10.0.0",
-    "typescript": "^5.0.2",
+    "typescript": "^6.0.0",
     "form-data": ">=4.0.4",
     "minimatch": ">=3.1.4 || >=10.2.3"
   },

--- a/src/configTypes.ts
+++ b/src/configTypes.ts
@@ -18,7 +18,7 @@ export type AwairPlatformConfig = {
   vocMw: number;
   occupancyDetection: boolean;
   occupancyOffset: number;
-  occupancyRestart: false;
+  occupancyRestart: boolean;
   occDetectedLevel: number;
   occNotDetectedLevel: number;
   enableModes: boolean;
@@ -26,6 +26,7 @@ export type AwairPlatformConfig = {
   verbose: boolean;
   development: boolean;
   modeTemp: boolean;
+  modeTime: boolean;
   ignoredDevices: [string];
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -555,9 +555,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
         }
 
 	    })
-    	.catch(error => {
+    	.catch((error: unknown) => {
 	      if(this.config.logging){
-	        this.log.error(`getUserInfo error: ${error.toJson}`);
+	        this.log.error(`getUserInfo error: ${error instanceof Error ? error.message : String(error)}`);
 	      }
 	    });
     return;
@@ -572,7 +572,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	    headers: {
 	      'Authorization': `Bearer ${this.config.token}`,
 	    },
-      validateStatus: (status: any) => status < 500, // Resolve only if the status code is less than 500
+      validateStatus: (status: number) => status < 500, // Resolve only if the status code is less than 500
 	  };
 
 	  await axios.get(url, options)
@@ -591,9 +591,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	        }
 	      }
 	    })
-    	.catch(error => {
+    	.catch((error: unknown) => {
 	      if(this.config.logging){
-	        this.log.error(`getAwairDevices error: ${error.toJson}`);
+	        this.log.error(`getAwairDevices error: ${error instanceof Error ? error.message : String(error)}`);
 	      }
 	    });
     return;
@@ -879,7 +879,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	    headers: {
 	      'Authorization': `Bearer ${this.config.token}`,
 	    },
-      validateStatus: (status: any) => status < 500, // Resolve only if the status code is less than 500
+      validateStatus: (status: number) => status < 500, // Resolve only if the status code is less than 500
 	  };
 
 	  await axios.get(url, options)
@@ -892,7 +892,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	      // compute time weighted average for each sensor's data
 	      const sensors: any = data
 	        .map(sensor => sensor.sensors) // create sensors data array of length 'this.limit'
-	        .reduce((a, b) => a.concat(b)) // flatten array of sensors (which is an array) to single-level array
+	        .reduce((a: any[], b: any[]) => a.concat(b), []) // flatten array of sensors (which is an array) to single-level array
 	        .reduce((a: any, b: any) => {
 	          a[b.comp] = a[b.comp] ? 0.5*(a[b.comp] + b.value) : b.value; 
 	          return a; // return time weighted average
@@ -933,23 +933,25 @@ class AwairPlatform implements DynamicPlatformPlugin {
 				
           for (const sensor in sensors) {
             switch (sensor) {
-              case 'temp': // Temperature (C)
+              case 'temp': { // Temperature (C)
                 const temperatureService = accessory.getService(`${accessory.context.name} Temp`);
                 if (temperatureService) {
                   temperatureService
                     .updateCharacteristic(hap.Characteristic.CurrentTemperature, parseFloat(sensors[sensor]));
                 }
                 break;
+              }
 			
-              case 'humid': // Humidity (%)
+              case 'humid': { // Humidity (%)
                 const humidityService = accessory.getService(`${accessory.context.name} Humidity`);
                 if (humidityService) {
                   humidityService
                     .updateCharacteristic(hap.Characteristic.CurrentRelativeHumidity, parseFloat(sensors[sensor]));
                 }
                 break;
+              }
 			
-              case 'co2': // Carbon Dioxide (ppm)
+              case 'co2': { // Carbon Dioxide (ppm)
                 const carbonDioxideService = accessory.getService(`${accessory.context.name} CO2`);
                 const co2 = sensors[sensor];
                 let co2Detected: any;
@@ -1014,8 +1016,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
                   }
                 }
                 break;
+              }
 			
-              case 'voc':
+              case 'voc': {
                 const voc = parseFloat(sensors[sensor]);
                 let tvoc = this.convertChemicals( accessory, voc, atmos, temp );
 
@@ -1053,8 +1056,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
                   }
                 }
                 break;
+              }
 			
-              case 'pm25': // PM2.5 (ug/m^3)
+              case 'pm25': { // PM2.5 (ug/m^3)
                 const pm25 = parseFloat(sensors[sensor]);
                 if(this.config.logging){
                   this.log.info(`[${accessory.context.serial}] PM2.5: ${pm25} ug/m^3)`);
@@ -1085,6 +1089,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
                   }
                 }
                 break;
+              }
 			
               case 'pm10': // PM10 (ug/m^3)
                 airQualityService
@@ -1106,9 +1111,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
           	}
 	        }
     		})
-	    .catch(error => {
+	    .catch((error: unknown) => {
 	      if(this.config.logging){
-	        this.log.error(`[${accessory.context.serial}] updateAirQualityData error: ${error.toJson}`);
+	        this.log.error(`[${accessory.context.serial}] updateAirQualityData error: ${error instanceof Error ? error.message : String(error)}`);
 	      }
 	  	});
     return;
@@ -1122,7 +1127,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
   
   async updateLocalAirQualityData(accessory: PlatformAccessory): Promise<void> {
     // Update air quality data for accessory of deviceId
-    const url = `http://${accessory.context.deviceType.substr(0, 10)}-${accessory.context.serial.substr(6)}.local/air-data/latest`;
+    const url = `http://${accessory.context.deviceType.slice(0, 10)}-${accessory.context.serial.slice(6)}.local/air-data/latest`;
 			
     await axios.get(url)
       .then(response => {
@@ -1158,23 +1163,25 @@ class AwairPlatform implements DynamicPlatformPlugin {
 
           for (const sensor in data) {
             switch (sensor) {
-              case 'temp': // Temperature (C)
+              case 'temp': { // Temperature (C)
                 const temperatureService = accessory.getService(`${accessory.context.name} Temp`);
                 if (temperatureService) {
                   temperatureService
                     .updateCharacteristic(hap.Characteristic.CurrentTemperature, parseFloat(data[sensor]));
                 }
                 break;
+              }
 			
-              case 'humid': // Humidity (%)
+              case 'humid': { // Humidity (%)
                 const humidityService = accessory.getService(`${accessory.context.name} Humidity`);
                 if (humidityService) {
                   humidityService
                     .updateCharacteristic(hap.Characteristic.CurrentRelativeHumidity, parseFloat(data[sensor]));
                 }
                 break;
+              }
 			
-              case 'co2': // Carbon Dioxide (ppm)
+              case 'co2': { // Carbon Dioxide (ppm)
                 const carbonDioxideService = accessory.getService(`${accessory.context.name} CO2`);
                 const co2 = data[sensor];
                 let co2Detected: any;
@@ -1239,8 +1246,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
                   }
                 }
                 break;
+              }
 			
-              case 'voc':
+              case 'voc': {
                 const voc = parseFloat(data[sensor]);
                 let tvoc = this.convertChemicals( accessory, voc, atmos, temp );
 
@@ -1278,8 +1286,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
                   }
                 }
                 break;
+              }
 			
-              case 'pm25': // PM2.5 (ug/m^3)
+              case 'pm25': { // PM2.5 (ug/m^3)
                 const pm25 = parseFloat(data[sensor]);
                 if(this.config.logging){
                   this.log.info(`[${accessory.context.serial}] PM2.5: ${pm25} ug/m^3)`);
@@ -1310,6 +1319,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
                   }
                 }
                 break;
+              }
 			
               case 'pm10_est': // PM10 (ug/m^3), Element and R2
                 airQualityService
@@ -1326,7 +1336,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
           	}
 	        }					
       })
-      .catch(error => {
+      .catch((error: unknown) => {
         if(this.config.logging){
           this.log.error(`[${accessory.context.serial}] getLocalAirQualityData error: ${error}`);
         }
@@ -1340,7 +1350,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	 * @param {object} accessory - accessory to obtain battery status
 	 */
   async getBatteryStatus(accessory: PlatformAccessory): Promise<void> {
-	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.substr(6)}.local/settings/config/data`;
+	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.slice(6)}.local/settings/config/data`;
 
 	  await axios.get(url)
     	.then(response => {
@@ -1366,7 +1376,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	          .updateCharacteristic(hap.Characteristic.StatusLowBattery, lowBattery); // <30%
 	      }
 	    })
-    	.catch(error => {
+    	.catch((error: unknown) => {
 	      if(this.config.logging){
 	        this.log.error(`[${accessory.context.serial}] getBatteryStatus error: ${error}`);
 	      }
@@ -1380,7 +1390,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	 * @param {object} accessory - accessory to obtain occupancy status
 	 */
   async getOccupancyStatus(accessory: PlatformAccessory): Promise<void> {
-	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.substr(6)}.local/air-data/latest`;
+	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.slice(6)}.local/air-data/latest`;
 
     await axios.get(url)
     	.then(response => {
@@ -1428,7 +1438,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	          .updateCharacteristic(hap.Characteristic.OccupancyDetected, occupancyStatus);
 	      }
 	    })
-    	.catch(error => {
+    	.catch((error: unknown) => {
 	      if(this.config.logging){
 	        this.log.error(`[${accessory.context.serial}] getOccupancyStatus error: ${error}`);
 	      }
@@ -1442,7 +1452,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	 * * @param {object} accessory - accessory to obtain light level status
 	 */
   async getLightLevel(accessory: PlatformAccessory): Promise<void> {
-	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.substr(6)}.local/air-data/latest`;
+	  const url = `http://${accessory.context.deviceType}-${accessory.context.serial.slice(6)}.local/air-data/latest`;
 		
 	  await axios.get(url)
     	.then(response => {
@@ -1457,7 +1467,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	          .updateCharacteristic(hap.Characteristic.CurrentAmbientLightLevel, omniLux);
 	      }
 	    })
-    	.catch(error => {
+    	.catch((error: unknown) => {
 	      if(this.config.logging){
 	        this.log.error(`[${accessory.context.serial}] getLightLevel error: ${error}`);
 	      }
@@ -1599,7 +1609,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	    headers: {
 	      'Authorization': `Bearer ${this.config.token}`,
 	    },
-      validateStatus: (status: any) => status < 500, // Resolve only if the status code is less than 500
+      validateStatus: (status: number) => status < 500, // Resolve only if the status code is less than 500
 	  };
 
 	  await axios.get(url, options)
@@ -1614,9 +1624,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	      });
 	    })
 			
-	    .catch(error => {
+	    .catch((error: unknown) => {
 	      if(this.config.logging){
-	        this.log.error(`[${accessory.context.serial}] getDisplayMode ${accessory.context.deviceUUID} error: ${error.toJson}`);
+	        this.log.error(`[${accessory.context.serial}] getDisplayMode ${accessory.context.deviceUUID} error: ${error instanceof Error ? error.message : String(error)}`);
 	      }
 	    });
     return;
@@ -1632,7 +1642,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	    headers: {
 	      'Authorization': `Bearer ${this.config.token}`,
 	    },
-      validateStatus: (status: any) => status < 500, // Resolve only if the status code is less than 500
+      validateStatus: (status: number) => status < 500, // Resolve only if the status code is less than 500
 	  };
 		
 	  await axios.put<any>(url, body, options)
@@ -1642,9 +1652,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	        this.log.info(`[${accessory.context.serial}] putDisplayMode response: ${response.data.message} for ${accessory.context.deviceUUID}`);
 	      }
 	    })
-	    .catch(error => {
+	    .catch((error: unknown) => {
 	      if(this.config.logging){
-	        this.log.error(`[${accessory.context.serial}] putDisplayMode error: ${error.toJson} for ${accessory.context.deviceUUID}`);
+	        this.log.error(`[${accessory.context.serial}] putDisplayMode error: ${error instanceof Error ? error.message : String(error)} for ${accessory.context.deviceUUID}`);
 	      }
 	    });
 	  accessory.context.displayMode = mode; // 'context.displayMode' is Mixed case
@@ -1825,7 +1835,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	    headers: {
 	      'Authorization': `Bearer ${this.config.token}`,
 	    },
-      validateStatus: (status: any) => status < 500, // Resolve only if the status code is less than 500
+      validateStatus: (status: number) => status < 500, // Resolve only if the status code is less than 500
 	  };
 
 	  await axios.get(url, options)
@@ -1842,9 +1852,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	      });
 	      accessory.context.ledBrightness = response.data.brightness;
 	    })
-	    .catch(error => {
+	    .catch((error: unknown) => {
 	      if(this.config.logging){
-	        this.log.error(`[${accessory.context.serial}] getLEDMode  ${accessory.context.deviceUUID} error: ${error.toJson}`);
+	        this.log.error(`[${accessory.context.serial}] getLEDMode  ${accessory.context.deviceUUID} error: ${error instanceof Error ? error.message : String(error)}`);
 	      }
 	    });
     return;
@@ -1863,7 +1873,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	    headers: {
 	      'Authorization': `Bearer ${this.config.token}`,
 	    },
-      validateStatus: (status: any) => status < 500, // Resolve only if the status code is less than 500
+      validateStatus: (status: number) => status < 500, // Resolve only if the status code is less than 500
 	  };
 
 	  await axios.put<any>(url, body, options)
@@ -1873,9 +1883,9 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	        this.log.info(`[${accessory.context.serial}] putLEDMode response: ${response.data.message} for ${accessory.context.deviceUUID}`);
 	      }
 	    })
-	    .catch(error => {
+	    .catch((error: unknown) => {
 	      if(this.config.logging){
-	        this.log.error(`[${accessory.context.serial}] putLEDMode error: ${error.toJson} for ${accessory.context.deviceUUID}`);
+	        this.log.error(`[${accessory.context.serial}] putLEDMode error: ${error instanceof Error ? error.message : String(error)} for ${accessory.context.deviceUUID}`);
 	      }
 	    });
 
@@ -1931,7 +1941,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	  const aqiArray = [];
 	  for (const sensor in sensors) {
 	    switch (sensor) {
-	      case 'voc':
+	      case 'voc': {
 	        let aqiVoc = parseFloat(sensors[sensor]);
 	        if (aqiVoc >= 0 && aqiVoc < 333) {
 	          aqiVoc = 1; // EXCELLENT
@@ -1948,7 +1958,8 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	        }
 	        aqiArray.push(aqiVoc);
 	        break;
-	      case 'pm25':
+	      }
+	      case 'pm25': {
 	        let aqiPm25 = parseFloat(sensors[sensor]);
 	        if (aqiPm25 >= 0 && aqiPm25 < 15) {
 	          aqiPm25 = 1; // EXCELLENT
@@ -1965,7 +1976,8 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	        }
 	        aqiArray.push(aqiPm25);
 	        break;
-	      case 'dust':
+	      }
+	      case 'dust': {
 	        let aqiDust = parseFloat(sensors[sensor]);
 	        if (aqiDust >= 0 && aqiDust < 50) {
 	          aqiDust = 1; // EXCELLENT
@@ -1982,6 +1994,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	        }
 	        aqiArray.push(aqiDust);
 	        break;
+	      }
 	      default:
 	        if(this.config.logging && this.config.verbose){
 	          // eslint-disable-next-line max-len
@@ -2001,7 +2014,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	  const aqiArray = [];
 	  for (const sensor in sensors) {
 	    switch (sensor) {
-	      case 'pm25':
+	      case 'pm25': {
 	        let aqiPm25 = parseFloat(sensors[sensor]);
 	        if (aqiPm25 >= 0 && aqiPm25 < 15) {
 	          aqiPm25 = 1; // EXCELLENT
@@ -2018,7 +2031,8 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	        }
 	        aqiArray.push(aqiPm25);
 	        break;
-	      case 'dust':
+	      }
+	      case 'dust': {
 	        let aqiDust = parseFloat(sensors[sensor]);
 	        if (aqiDust >= 0 && aqiDust < 50) {
 	          aqiDust = 1; // EXCELLENT
@@ -2035,6 +2049,7 @@ class AwairPlatform implements DynamicPlatformPlugin {
 	        }
 	        aqiArray.push(aqiDust);
 	        break;
+	      }
 	      default:
 	        if(this.config.logging && this.config.verbose){
 	          // eslint-disable-next-line max-len

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "target": "ES2018",
     "module": "commonjs",
     "lib": [
@@ -10,6 +11,7 @@
       "dom"
     ],
     "baseUrl": ".",
+    "rootDir": "src",
     "outDir": "dist",
     "sourceMap": true,
     "allowJs": true,
@@ -23,6 +25,6 @@
     }
   },
   "include": [
-    "src/**/*"
+    "./src/**/*"
   ]
 }


### PR DESCRIPTION
## Summary

Addresses all breaking changes required for TypeScript 6.0 compatibility across `src/index.ts` and `src/configTypes.ts`.

- **`substr()` removed** — replaced 4 calls with `slice()` (`updateLocalAirQualityData`, `getBatteryStatus`, `getOccupancyStatus`, `getLightLevel`)
- **Lexical declarations in `switch` cases** — added block-scope braces `{}` to all `case` clauses that declare `const`/`let` variables (`'temp'`, `'humid'`, `'co2'`, `'voc'`, `'pm25'`, `'dust'` across cloud, local, AQI, and PM conversion methods)
- **`catch` error variables typed `unknown`** — fixed 9 handlers; replaced `error.toJson` (incorrect property, would throw at runtime) with `error instanceof Error ? error.message : String(error)`
- **`validateStatus` parameter** — changed from `any` to `number` in all 6 axios option objects
- **`reduce()` without typed initial value** — added explicit `[]` initial value and typed accumulator on the sensor-array flatten call
- **`modeTime` missing from `AwairPlatformConfig`** — added `modeTime: boolean`; the field was already read in `index.ts` but absent from the type, causing a strict-mode error
- **`occupancyRestart` literal type** — changed from `false` to `boolean`
- **`tsconfig.json`** — added `"ignoreDeprecations": "6.0"` and `rootDir`; bumped TypeScript devDependency to `^6.0.0`
- **Node.js engine range** — updated to `^22.10.0 || ^24.11.0 || ^26.1.0`

## Test plan

- [ ] `npm run build` compiles cleanly with TypeScript 6.0 installed
- [ ] Cloud API polling path exercises all sensor switch cases without runtime errors
- [ ] Local API path (awair-omni / awair-mint) correctly constructs `.local` URLs using `slice()`
- [ ] Error messages from failed axios calls appear in Homebridge log (verifies catch handlers work)
- [ ] `modeTime` config option correctly toggles 24hr display mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)